### PR TITLE
fix: Large RPC ID

### DIFF
--- a/src/rpc-client.js
+++ b/src/rpc-client.js
@@ -19,7 +19,7 @@ module.exports = class RpcClient {
 	constructor(provider) {
 		this.provider = provider;
 		this._chainId = null;
-		this._nextRpcId = _.random(1, 2**64);
+		this._nextRpcId = _.random(1, 2**32);
 	}
 
 	async getDefaultAccount() {


### PR DESCRIPTION
Quicknode (and perhaps other providers) doesn't like large RPC Ids.

```
curl --location --request POST 'RPC_URL' \
--header 'Content-Type: application/json' \
--data-raw '{
    "method": "eth_blockNumber",
    "params": [],
    "id": 10114294196968190000,
    "jsonrpc": "2.0"
}'
```

```json
{
    "jsonrpc": "2.0",
    "id": null,
    "error": {
        "code": -32600,
        "message": "failed to parse request"
    }
}
```